### PR TITLE
feat: Support Shared Drives

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -35,6 +35,8 @@ server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
   const params: any = {
     pageSize,
     fields: "nextPageToken, files(id, name, mimeType)",
+    supportsAllDrives: true,
+    includeItemsFromAllDrives: true,
   };
 
   if (request.params?.cursor) {
@@ -59,6 +61,7 @@ async function readFileContent(fileId: string) {
   const file = await drive.files.get({
     fileId,
     fields: "mimeType",
+    supportsAllDrives: true,
   });
 
   // For Google Docs/Sheets/etc we need to export
@@ -94,7 +97,7 @@ async function readFileContent(fileId: string) {
 
   // For regular files download content
   const res = await drive.files.get(
-    { fileId, alt: "media" },
+    { fileId, alt: "media", supportsAllDrives: true },
     { responseType: "arraybuffer" },
   );
   const mimeType = file.data.mimeType || "application/octet-stream";
@@ -172,6 +175,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       q: formattedQuery,
       pageSize: 10,
       fields: "files(id, name, mimeType, modifiedTime, size)",
+      supportsAllDrives: true,
+      includeItemsFromAllDrives: true,
     });
     
     const fileList = res.data.files


### PR DESCRIPTION
# Overview

  This pull request adds support for Google Shared Drives (formerly Team Drives) to the gdrive-mcp-server. This allows the server to
  list, read, and search for files stored in Shared Drives, in addition to the user's personal "My Drive".

Fix #9 

# Why this Pull Request is necessary

  Currently, the server can only access files in the user's "My Drive". This prevents users who organize their files in Shared Drives
  from using this tool effectively. This pull request addresses this limitation by enabling Shared Drive support in the Google Drive
  API calls.

#  Expected behavior

  With this change, the server will be able to:

   * List files from all Shared Drives that the user has access to.
   * Read the content of files stored in Shared Drives.
   * Search for files within all accessible Shared Drives.

#  Current behavior

  Prior to this change, the server could only:

   * List files from the user's "My Drive".
   * Read the content of files stored in "My Drive".
   * Search for files within "My Drive".
   * Attempts to access files in Shared Drives would fail or the files would not appear in the results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Nuevas Características
* Acceso ampliado: busque, liste y descargue archivos de todas sus unidades, incluidas las unidades compartidas.
* Las operaciones de lectura y búsqueda de archivos ahora funcionan en todos sus espacios disponibles sin limitaciones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->